### PR TITLE
add --genomeLoad LoadAndRemove

### DIFF
--- a/iCount/externals/star.py
+++ b/iCount/externals/star.py
@@ -201,7 +201,7 @@ def map_reads(reads, genome_index, out_dir, annotation='', multimax=10, mismatch
         '--outFilterMismatchNmax', '{:d}'.format(mismatches),
         '--alignEndsType', 'EndToEnd',
         ## Share memory
-        '--genomeLoad LoadAndRemove',
+        '--genomeLoad', 'LoadAndRemove',
         # otherwise soft-clipping of the starts and ends may produce too
         # many multiple hits
         '--outSAMtype', 'BAM', 'SortedByCoordinate',

--- a/iCount/externals/star.py
+++ b/iCount/externals/star.py
@@ -200,6 +200,8 @@ def map_reads(reads, genome_index, out_dir, annotation='', multimax=10, mismatch
         '--outFilterMultimapNmax', '{:d}'.format(multimax),
         '--outFilterMismatchNmax', '{:d}'.format(mismatches),
         '--alignEndsType', 'EndToEnd',
+        ## Share memory
+        '--genomeLoad LoadAndRemove',
         # otherwise soft-clipping of the starts and ends may produce too
         # many multiple hits
         '--outSAMtype', 'BAM', 'SortedByCoordinate',


### PR DESCRIPTION
Share STAR index in memory by this option. So I can run iCount map for multiple samples in parallel.