### PR TITLE
setup: Fix docker build and BED formatting issues in bedtools, fixes #174

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.tox
+.git
+storage_docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,14 +20,14 @@ cache:
 install:
     - pip install tox
     # install bedtools
-    - wget https://github.com/arq5x/bedtools2/releases/download/v2.26.0/bedtools-2.26.0.tar.gz
-    - tar -zxvf bedtools-2.26.0.tar.gz
+    - wget https://github.com/arq5x/bedtools2/releases/download/v2.27.1/bedtools-2.27.1.tar.gz
+    - tar -zxvf bedtools-2.27.1.tar.gz
     - pushd bedtools2 && make && popd
     - export PATH=$PATH:$PWD/bedtools2/bin/
     # install STAR
-    - wget https://github.com/alexdobin/STAR/archive/2.5.2b.tar.gz
-    - tar -xzf 2.5.2b.tar.gz
-    - export PATH=$PATH:$PWD/STAR-2.5.2b/bin/Linux_x86_64/
+    - wget https://github.com/alexdobin/STAR/archive/2.6.1a.tar.gz
+    - tar -xzf 2.6.1a.tar.gz
+    - export PATH=$PATH:$PWD/STAR-2.6.1a/bin/Linux_x86_64/
 
 matrix:
   include:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04.3
+FROM ubuntu:16.04
 MAINTAINER Tomaz Curk <tomazc@gmail.com>
 
 # thanks to https://github.com/bschiffthaler/ngs/blob/master/base/Dockerfile
@@ -7,6 +7,7 @@ MAINTAINER Tomaz Curk <tomazc@gmail.com>
 RUN useradd -m -d /home/icuser icuser
 
 # update system
+RUN sed -Ei 's/^# deb-src /deb-src /' /etc/apt/sources.list
 RUN apt-get update && apt-get upgrade -y && \
     apt-get install -y \
     build-essential \
@@ -15,6 +16,7 @@ RUN apt-get update && apt-get upgrade -y && \
     wget \
     g++ \
     make \
+    binutils \
     python3 \
     python3-pip \
     python3-setuptools \
@@ -41,8 +43,8 @@ RUN apt-get install -y \
 ### bedtools, need at least version 2.26, where merge command reports strand
 # RUN apt-get install -y bedtools
 WORKDIR /tmp/bedtools
-RUN wget https://github.com/arq5x/bedtools2/releases/download/v2.26.0/bedtools-2.26.0.tar.gz
-RUN tar -zxvf bedtools-2.26.0.tar.gz
+RUN wget https://github.com/arq5x/bedtools2/releases/download/v2.27.1/bedtools-2.27.1.tar.gz
+RUN tar -zxvf bedtools-2.27.1.tar.gz
 WORKDIR /tmp/bedtools/bedtools2
 RUN make
 RUN make install
@@ -52,9 +54,9 @@ RUN rm -rfv bedtools
 #################
 ### RNA-star
 WORKDIR /tmp/STAR
-RUN wget https://github.com/alexdobin/STAR/archive/STAR_2.4.2a.tar.gz
-RUN tar -xvzf STAR_2.4.2a.tar.gz
-WORKDIR /tmp/STAR/STAR-STAR_2.4.2a/source
+RUN wget https://github.com/alexdobin/STAR/archive/2.6.1a.tar.gz
+RUN tar -xvzf 2.6.1a.tar.gz
+WORKDIR /tmp/STAR/STAR-2.6.1a/source
 RUN make STAR
 RUN mkdir -p /home/icuser/bin && cp STAR /home/icuser/bin
 WORKDIR /tmp
@@ -79,8 +81,7 @@ RUN chown -R icuser.icuser /home/icuser
 USER icuser
 WORKDIR /home/icuser/iCount_src
 
-RUN ../.icountenv/bin/pip install -e .
-RUN ../.icountenv/bin/pip install -e .[docs,tests]
+RUN ../.icountenv/bin/pip install -e .[docs,test]
 
 USER root
 RUN echo "source /home/icuser/.icountenv/bin/activate" >> /etc/bash.bashrc

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -26,7 +26,7 @@ directory::
 
 Prepare iCount for development::
 
-    pip install -e .[tests]
+    pip install -e .[test]
 
 .. note::
 
@@ -179,7 +179,7 @@ Tests for iCount python package and corresponding CLI.
 ------------------------------------------------------
 
 There are two types of tests: *unit* and *functional* (regression) tests.
-Continious development testing supported on GitHub is also explained in the
+Continuous development testing supported on GitHub is also explained in the
 corresponding section.
 
 

--- a/iCount/files/bed.py
+++ b/iCount/files/bed.py
@@ -105,7 +105,7 @@ def merge_bed(sites_grouped, sites):
     # c=5, o='sum' - when merging intervals, make operation 'sum' on column 5 (score)
     LOGGER.info('Merging files...')
     merged = pybedtools.BedTool(joined.name).sort().merge(
-        s=True, d=-1, c=5, o='sum').sort().saveas()
+        s=True, d=-1, c=(5, 6), o=('sum', 'distinct')).sort().saveas()
 
     # Columns are now shuffled to: chrom-start-stop-strand-score
     # Reorder to: chrom-start-stop-empty_name-score-strand
@@ -113,7 +113,7 @@ def merge_bed(sites_grouped, sites):
 
     LOGGER.info('Saving results...')
     result = pybedtools.BedTool(pybedtools.create_interval_from_list(
-        i[:3] + ['.', i[4], i[3]]) for i in merged).saveas()
+        i[:3] + ['.'] + i[3:]) for i in merged).saveas()
     result.saveas(sites_grouped)
 
     LOGGER.info('Done. Results saved to: %s', os.path.abspath(result.fn))

--- a/iCount/tests/test_clusters.py
+++ b/iCount/tests/test_clusters.py
@@ -15,11 +15,25 @@ class TestClusters(unittest.TestCase):
     def setUp(self):
         warnings.simplefilter("ignore", ResourceWarning)
 
-    def test_fix_proper_bed6_format(self):
-        feature = create_interval_from_list(['1', '1', '10', '+', '5'])
+    def test_fix_bed6_empytname(self):
+        feature = create_interval_from_list(['1', '1', '10', '.', '5', '+'])
 
-        converted = clusters._fix_bed6(feature)
+        converted = clusters._fix_bed6_emptyname(feature)
         expected = create_interval_from_list(['1', '1', '10', '', '5', '+'])
+        self.assertEqual(expected, converted)
+
+    def test_fix_bed6_empytname2(self):
+        feature = create_interval_from_list(['1', '1', '10', '.,a', '5', '+'])
+
+        converted = clusters._fix_bed6_emptyname(feature)
+        expected = create_interval_from_list(['1', '1', '10', 'a', '5', '+'])
+        self.assertEqual(expected, converted)
+
+    def test_fix_bed6_empytname3(self):
+        feature = create_interval_from_list(['1', '1', '10', 'b,.,a', '5', '+'])
+
+        converted = clusters._fix_bed6_emptyname(feature)
+        expected = create_interval_from_list(['1', '1', '10', 'b,a', '5', '+'])
         self.assertEqual(expected, converted)
 
     def test_clusters(self):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bdist_wheel]
-python-tag = py34,py35
+python-tag = py35,py36
 
 [pycodestyle]
 max-line-length=119
@@ -12,3 +12,7 @@ exclude = setup.py
 
 [pydocstyle]
 match-dir = (?!tests|\.).*
+
+[check-manifest]
+ignore =
+    .dockerignore


### PR DESCRIPTION
- Version of STAR was bumped to 2.6.1a.
- Version of bedtools2 was bumped to 2.27.1. The output of `merge` and `cat` commands changed from version (2.26.0).