### PR TITLE
env: Add support for python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: trusty
+dist: xenial
 language: python
 
 addons:
@@ -35,12 +35,14 @@ matrix:
       python: "3.5"
     - env: TOX_ENV=py36
       python: "3.6"
+    - env: TOX_ENV=py37
+      python: "3.7"
     - env: TOX_ENV=linters
-      python: "3.6"
+      python: "3.7"
     - env: TOX_ENV=docs
-      python: "3.6"
+      python: "3.7"
     - env: TOX_ENV=packaging
-      python: "3.6"
+      python: "3.7"
 
 script:
   - tox -e $TOX_ENV

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -230,15 +230,16 @@ waiting for Travis to do the checks, tox can run on local machine::
 
     # Run all tox tests
     tox
-    # Run only a single environment (for example unittests in Python 3.5)
-    tox -e py35
+    # Run only a single environment (for example unittests in Python 3.7)
+    tox -e py37
 
 Tox enables to test code against different versions of Python and also perform
 code-style checks. This is achieved by different *environments*. Currently, we
 test three of them:
 
+    * py37 (Python 3.7)
+    * py36 (Python 3.6)
     * py35 (Python 3.5)
-    * py34 (Python 3.4)
     * linters (wraps pylint, PEP8/pycodestyle and PEP257/pydocstyle)
 
 For more info check ``tox.ini`` and ``.travis.yml`` in packyge root directory.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bdist_wheel]
-python-tag = py35,py36
+python-tag = py35,py36,py37
 
 [pycodestyle]
 max-line-length=119

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py36,docs,linters,packaging
+envlist = py35,py36,py37,docs,linters,packaging
 skip_missing_interpreters = True
 
 # NOTE: Don't use 'deps = .[<extra-requirements>]' tox option since we


### PR DESCRIPTION
Bump Linux distribution from `trusty` to `xenial` for python 3.7 support.
(`xenial` (16.04) is also used in Docker.)